### PR TITLE
fix Hunter Stuck in Combat Animation

### DIFF
--- a/src/server/game/Handlers/CombatHandler.cpp
+++ b/src/server/game/Handlers/CombatHandler.cpp
@@ -62,7 +62,11 @@ void WorldSession::HandleAttackSwingOpcode(WorldPacket& recvData)
         }
     }
 
-    _player->Attack(pEnemy, true);
+    if (!_player->Attack(pEnemy, true))
+    {
+        // attack was not started (e.g. target is evading, player is mounted) - stop attack state at client
+        _player->SendMeleeAttackStop(pEnemy);
+    }
 }
 
 void WorldSession::HandleAttackStopOpcode(WorldPacket& /*recvData*/)


### PR DESCRIPTION
Hunter could get stuck in combat animation.
mostly happened when attacking an enemy that is evading with a melee attack.