### PR TITLE
Remove Unlearned Spell Messages for Pets

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -1954,12 +1954,12 @@ bool Pet::unlearnSpell(uint32 spell_id, bool learn_prev, bool clear_ab)
 {
     if (removeSpell(spell_id, learn_prev, clear_ab))
     {
-        if (!m_loading)
+        /* if (!m_loading)
         {
             WorldPackets::Pet::PetUnlearnedSpell packet;
             packet.SpellID = spell_id;
             m_owner->SendDirectMessage(packet.Write());
-        }
+        } */
 
         return true;
     }


### PR DESCRIPTION
needed to avoid spam of unlearned pet spells.