### PR TITLE
Fix Invisible Items Inside Bag

### DIFF
--- a/src/server/game/Entities/Item/Item.cpp
+++ b/src/server/game/Entities/Item/Item.cpp
@@ -1164,10 +1164,15 @@ void Item::BuildUpdate(UpdateDataMapType& data_map)
     ClearUpdateMask(false);
 }
 
-void Item::AddToObjectUpdate()
+bool Item::AddToObjectUpdate()
 {
     if (Player* owner = GetOwner())
+    {
         owner->GetMap()->AddUpdateObject(this);
+        return true;
+    }
+
+    return false;
 }
 
 void Item::RemoveFromObjectUpdate()

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -358,7 +358,7 @@ public:
     bool CheckSoulboundTradeExpire();
 
     void BuildUpdate(UpdateDataMapType& data_map) override;
-    void AddToObjectUpdate() override;
+    bool AddToObjectUpdate() override;
     void RemoveFromObjectUpdate() override;
 
     [[nodiscard]] uint32 GetScriptId() const { return GetTemplate()->ScriptId; }

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -513,10 +513,7 @@ void Object::BuildValuesUpdate(uint8 updateType, ByteBuffer* data, Player* targe
 void Object::AddToObjectUpdateIfNeeded()
 {
     if (m_inWorld && !m_objectUpdated)
-    {
-        AddToObjectUpdate();
-        m_objectUpdated = true;
-    }
+        m_objectUpdated = AddToObjectUpdate();
 }
 
 void Object::ClearUpdateMask(bool remove)
@@ -3115,9 +3112,10 @@ void WorldObject::GetCreaturesWithEntryInRange(std::list<Creature*>& creatureLis
     Cell::VisitObjects(this, searcher, radius);
 }
 
-void WorldObject::AddToObjectUpdate()
+bool WorldObject::AddToObjectUpdate()
 {
     GetMap()->AddUpdateObject(this);
+    return true;
 }
 
 void WorldObject::RemoveFromObjectUpdate()

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -267,7 +267,7 @@ protected:
 
     uint16 _fieldNotifyFlags;
 
-    virtual void AddToObjectUpdate() = 0;
+    virtual bool AddToObjectUpdate() = 0;
     virtual void RemoveFromObjectUpdate() = 0;
     void AddToObjectUpdateIfNeeded();
 
@@ -661,7 +661,7 @@ public:
     void SetPositionDataUpdate();
     void UpdatePositionData();
 
-    void AddToObjectUpdate() override;
+    bool AddToObjectUpdate() override;
     void RemoveFromObjectUpdate() override;
 
     //relocation and visibility system functions


### PR DESCRIPTION
items would be invisible, after taking a bag from the guild bank
moving the bag to a different slot would temporary make the items visible.
relogging would solve it as well.

this PR fixes this issue.